### PR TITLE
adding LRU cache between DB and server

### DIFF
--- a/blog.controller.js
+++ b/blog.controller.js
@@ -1,56 +1,76 @@
+const LRU = require("./cache");
+const cache = new LRU(10);
 
-const create = (client)=>(req,res,next)=>{
+const create = client => (req, res, next) => {
+  cache.delete(0);
   const post = req.body;
-  console.log('posting', post);
+  console.log("posting", post);
   client.query(
-    'insert into posts(author, title, body) values ($1, $2, $3)', 
-    [post.author, post.title, post.body], 
-    (err, ans)=>{
-      if(err){
-        return next('error while posting!');
+    "insert into posts(author, title, body) values ($1, $2, $3)",
+    [post.author, post.title, post.body],
+    (err, ans) => {
+      if (err) {
+        return next("error while posting!");
       }
       console.log(ans);
-      return res.status(200).json({confirmed: true})
-    })
-}
-
-const read = (client)=>(req,res,next)=>{
-  console.log('retrieving');
-  if(req.params.id === '0'){
-    console.log('getting most recent post');
-    client.query('select * from posts order by id desc limit 1',(err, ans)=>{
-      if(err){
-        res.status(404)
-        return next(err);
-      }
-      res.json(ans.rows);
-    })
-  }else{
-    console.log('getting id', req.params.id);
-    client.query('SELECT * FROM posts WHERE ID = $1', [req.params.id], (err, ans) => {
-      if(err){
-        res.status(404)
-        return next(err);
-      }
-      res.json(ans.rows);
-    })
-  }
-}
-
-const update = (client)=>(req,res,next)=>{
-  const {author, title, body} = req.body;
-  console.log('updating post with id', req.params.id)
-  client.query('UPDATE posts set author = $1, title = $2, body = $3 where id = $4 ', [author, title, body, req.params.id], (err, ans) => {
-    if(err){
-      res.status(404)
-      return next(err);
+      return res.status(200).json({ confirmed: true });
     }
-    return res.json(ans)
-  })
-}
+  );
+};
+
+const read = client => (req, res, next) => {
+  console.log("retrieving");
+  const cached = cache.get(req.params.id);
+  if (cached) {
+    console.log("retrieving cached post", req.params.id);
+    return res.json(cached);
+  }
+  if (req.params.id === "0") {
+    console.log("getting most recent post");
+    client.query("select * from posts order by id desc limit 1", (err, ans) => {
+      if (err) {
+        res.status(404);
+        return next(err);
+      }
+      cache.set(req.params.id, ans.rows);
+      res.json(ans.rows);
+    });
+  } else {
+    console.log("getting id", req.params.id);
+    client.query(
+      "SELECT * FROM posts WHERE ID = $1",
+      [req.params.id],
+      (err, ans) => {
+        if (err) {
+          res.status(404);
+          return next(err);
+        }
+        cache.set(req.params.id, ans.rows);
+        res.json(ans.rows);
+      }
+    );
+  }
+};
+
+const update = client => (req, res, next) => {
+  const { author, title, body } = req.body;
+  console.log("updating post with id", req.params.id);
+  cache.delete(req.params.id);
+  client.query(
+    "UPDATE posts set author = $1, title = $2, body = $3 where id = $4 ",
+    [author, title, body, req.params.id],
+    (err, ans) => {
+      if (err) {
+        res.status(404);
+        return next(err);
+      }
+      return res.json(ans);
+    }
+  );
+};
 
 module.exports = client => ({
   create: create(client),
   readById: read(client),
   updateById: update(client)
-})
+});

--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,101 @@
+//LRU cache for the db layer
+//LRU controls DLL controls DllNode
+function LRU(maxSize) {
+  this.keys = {};
+  this.q = new Dll();
+  this.maxSize = maxSize;
+}
+
+//access should move it to the top of the list
+LRU.prototype.get = function(key) {
+  if (!this.keys[key]) {
+    return null;
+  }
+  const vals = this.keys[key].removeNode();
+  this.q.insertFront(key, vals.removed.val);
+  return vals.removed.val;
+};
+
+//set should upsert
+//if updating, shift to the front
+LRU.prototype.set = function(key, val) {
+  if (this.keys[key]) {
+    this.keys[key].removeNode();
+  } else if (this.q.length >= this.maxSize) {
+    const removed = this.q.removeEnd();
+    delete this.keys[removed.key];
+  }
+  const newNode = this.q.insertFront(key, val);
+  this.keys[key] = newNode;
+};
+
+LRU.prototype.delete = function(key) {
+  if (!this.keys[key]) {
+    return null;
+  }
+  let target = this.keys[key];
+  if (this.q.tail === target) {
+    this.q.tail = target.prev;
+  }
+  if (this.q.head === target) {
+    this.q.head = target.next;
+  }
+  const removed = target.removeNode();
+  this.q.length -= 1;
+  delete this.keys[key];
+  return removed;
+};
+
+function Dll() {
+  this.length = 0;
+  this.head = null;
+  this.tail = null;
+}
+
+Dll.prototype.insertFront = function(key, val) {
+  this.length++;
+  const newNode = new DllNode(key, val);
+  newNode.next = this.head;
+  if (newNode.next) {
+    newNode.next.prev = newNode;
+  }
+  this.head = newNode;
+  if (!this.tail) {
+    this.tail = newNode;
+  }
+  return newNode;
+};
+
+Dll.prototype.removeEnd = function() {
+  if (!this.tail) {
+    return null;
+  }
+  this.length--;
+  const removed = this.tail;
+  this.tail = removed.prev;
+  if (this.tail) {
+    this.tail.next = null;
+  }
+  removed.prev = null;
+  return removed;
+};
+
+function DllNode(key, val) {
+  this.key = key;
+  this.val = val;
+  this.next = null;
+  this.prev = null;
+}
+
+DllNode.prototype.removeNode = function() {
+  if (this.prev && this.next) {
+    this.prev.next = this.next.prev;
+  } else if (this.prev && !this.next) {
+    this.prev.next = null;
+  } else if (this.next) {
+    this.next.prev = null;
+  }
+  return { removed: this, prev: this.prev, next: this.next };
+};
+
+module.exports = LRU;

--- a/cache.js
+++ b/cache.js
@@ -9,7 +9,7 @@ function LRU(maxSize) {
 //access should move it to the top of the list
 LRU.prototype.get = function(key) {
   if (!this.keys[key]) {
-    return null;
+    return undefined;
   }
   const vals = this.keys[key].removeNode();
   this.q.insertFront(key, vals.removed.val);

--- a/index.js
+++ b/index.js
@@ -1,47 +1,47 @@
-require('dotenv').config();
-const express = require('express');
-const cookieParser = require('cookie-parser');
-const cors = require('cors');
+require("dotenv").config();
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const cors = require("cors");
 const app = express();
 const port = 3000;
-const bodyParser = require('body-parser');
-const { Client } = require('pg');
+const bodyParser = require("body-parser");
+const { Client } = require("pg");
 const client = new Client();
-const blogController = require('./blog.controller')(client);
+const blogController = require("./blog.controller")(client);
 client.connect();
 let pass;
-console.log('retreiving pass from db');
-client.query('select * from users where id = 1', (err, ans)=>{
-  if(ans && ans.rows[0] && ans.rows[0].password){
+console.log("retreiving pass from db");
+client.query("select * from users where id = 1", (err, ans) => {
+  if (ans && ans.rows[0] && ans.rows[0].password) {
     pass = ans.rows[0].password;
-    console.log('cached pass on server');
+    console.log("cached pass on server");
   }
-})
+});
 
 app.use(cors());
 app.use(bodyParser.json());
 app.use(cookieParser());
 
-app.use(express.static('../home/build'));
+app.use(express.static("../home/build"));
 
-app.use((err, req, res, next)=>{
+app.use((err, req, res, next) => {
   console.error(err.stack);
   res.send(err);
 });
 
-const authController = (req, res, next)=>{
-  console.log('receiving password', req.body.pass);
-  if(req.body.pass !== pass){
+const authController = (req, res, next) => {
+  console.log("receiving password", req.body.pass);
+  if (req.body.pass !== pass) {
     return next("auth error!");
-  }else{
-    console.log('auth success');
+  } else {
+    console.log("auth success");
     return next();
   }
-}
+};
 
-app.post('/api/posts', authController, blogController.create);
+app.post("/api/posts", authController, blogController.create);
 
-app.get('/api/posts/:id', blogController.readById);
-app.post('/api/posts/:id', authController, blogController.updateById);
+app.get("/api/posts/:id", blogController.readById);
+app.post("/api/posts/:id", authController, blogController.updateById);
 
-app.listen(port, ()=>console.log(`listening on ${port}`));
+app.listen(port, () => console.log(`listening on ${port}`));


### PR DESCRIPTION
Now uses inmemory LRU cache to save blogposts

LRU Cache:
* instantiate an LRU cache with `new LRU(maxSize)`, where maxSize is the maximum number of items in the cache.
* LRU cache can use `set`, `get`, and `delete` to upsert items, retrieve them, and delete them.
  * `set` upserts an item in the cache, and moves it to the front of the most recently used queue
  * `get` retrieves an item in the cache and moves its spot in the queue to the front. returns the cached value if found, or undefined if not.
  * `delete` removes an item from the cache, returning the item removed or undefined if nothing was removed.

blog controller:
* Checks LRU cache for blogposts before retrieving from PG
* Removes appropriate items from LRU cache after updating or creating item